### PR TITLE
feat(sprint-2): plugin system with ClockItem and ItemManager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [dependencies]
 # Easy error handling
 anyhow = "1.0.98"
+chrono = "0.4.41"
 # XDG directory specification
 directories = "6.0.0"
 glib = "0.20.12"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,51 @@ By default, the system config lives in the repository under `config/deafult.toml
 
 To override settings (for example, to change which items appear or tweak refresh intervals), copy this file into your user config directory `$XDG_CONFIG_HOME/panel-rs`. You can then edit `$XDG_CONFIG_HOME/panel-rs/config.toml` to your liking. When you next run `panel-rs`, it will load your user config instead of the bundled default.
 
+## Plugin Architecture
+
+This bar uses a **plugin** system for its items:
+
+1. **`Item` trait**  
+   Defined in `src/core/item.rs`, it requires:
+   - `fn name(&self) -> &str` — a unique identifier.
+   - `fn widget(&self) -> gtk4::Widget` — builds and returns the UI element.
+   - `fn start(&self) -> Result<()>` — kicks off any background timers or signals.
+
+2. **`ItemManager`**  
+   In `src/core/item_manager.rs`, it:
+   - Loads `Config::items: Vec<String>`.
+   - Instantiates the matching `Item` implementations (e.g. `ClockItem`).
+   - Exposes `items()` so the `WindowManager` can build the UI.
+
+3. **Adding a new item**  
+   To introduce a new plugin:
+   - Create `src/core/items/<your_item>.rs`.
+   - Implement the `Item` trait for your struct.
+   - Add a `match` arm in `ItemManager::load()` mapping your item’s name to its constructor.
+   - Write unit tests under the module and update README with examples.
+
+### Example: `ClockItem`
+
+```rust
+use crate::core::item::Item;
+use gtk4::Label;
+use std::error::Error;
+
+pub struct ClockItem { /* ... */ }
+
+impl Item for ClockItem {
+    fn name(&self) -> &str { "clock" }
+    fn widget(&self) -> gtk4::Widget {
+        let label = Label::new(None);
+        label.set_text("00:00:00");
+        label.upcast()
+    }
+    fn start(&self) -> Result<(), Box<dyn Error>> {
+        // schedule updates...
+        Ok(())
+    }
+}
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,10 @@
+/* assets/style.css */
+#panel-window {
+	background-color: #222;
+}
+
+.clock-label {
+	color: #fff;
+	font-size: 18px;
+	padding: 0 10px;
+}

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -9,7 +9,7 @@ use tracing::info;
 
 use super::config_loader::config_paths;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     // Which items to enable in the bar, in order
     pub items: Vec<String>,

--- a/src/core/item.rs
+++ b/src/core/item.rs
@@ -22,3 +22,31 @@ pub trait Item {
     // Called after the widget is in the widget tree and show.
     fn start(&self) -> Result<()>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Item;
+    use anyhow::Error;
+    use gtk4::prelude::Cast;
+
+    struct DummyItem;
+    impl Item for DummyItem {
+        fn name(&self) -> &str { "dummy" }
+        fn widget(&self) -> gtk4::Widget {
+            // we deliberately don’t call Label::new() here
+            // a real Item MUST provide a widget(), but for this
+            // unit test we simply return a placeholder:
+            gtk4::Box::new(gtk4::Orientation::Horizontal, 0).upcast()
+        }
+        fn start(&self) -> Result<(), Error> { Ok(()) }
+    }
+
+    #[test]
+    fn dummy_item_behaves() {
+        let d = DummyItem;
+        // Name is logic only, no GTK needed
+        assert_eq!(d.name(), "dummy");
+        // widget() may return anything that upcasts to Widget
+        assert!(d.start().is_ok());
+    }
+}

--- a/src/core/item.rs
+++ b/src/core/item.rs
@@ -1,7 +1,6 @@
 // src/core/item.rs
 
 use anyhow::Result;
-use gtk4::prelude::*;
 use gtk4::Widget;
 
 // Core trait for a status-bar item plugin.

--- a/src/core/item.rs
+++ b/src/core/item.rs
@@ -1,0 +1,25 @@
+// src/core/item.rs
+
+use anyhow::Result;
+use gtk4::prelude::*;
+use gtk4::Widget;
+
+// Core trait for a status-bar item plugin.
+//
+// Each item must:
+// 1. provide a unique `name()` for identification;
+// 2. build and return its root `Widget` via `widget()`;
+// 3. start its internal logic (timers, event handlers) once mounted.
+pub trait Item {
+    // A short, unique identifier for the item
+    fn name(&self) -> &str;
+
+    // Construct the GTK widget(s) representing the item.
+    // This is called once on `connect_activate`.
+    // The returned widget will be appended to the bar's container.
+    fn widget(&self) -> Widget;
+
+    // Kick off any ongoing tasks.
+    // Called after the widget is in the widget tree and show.
+    fn start(&self) -> Result<()>;
+}

--- a/src/core/item.rs
+++ b/src/core/item.rs
@@ -31,14 +31,18 @@ mod tests {
 
     struct DummyItem;
     impl Item for DummyItem {
-        fn name(&self) -> &str { "dummy" }
+        fn name(&self) -> &str {
+            "dummy"
+        }
         fn widget(&self) -> gtk4::Widget {
             // we deliberately don’t call Label::new() here
             // a real Item MUST provide a widget(), but for this
             // unit test we simply return a placeholder:
             gtk4::Box::new(gtk4::Orientation::Horizontal, 0).upcast()
         }
-        fn start(&self) -> Result<(), Error> { Ok(()) }
+        fn start(&self) -> Result<(), Error> {
+            Ok(())
+        }
     }
 
     #[test]

--- a/src/core/item_manager.rs
+++ b/src/core/item_manager.rs
@@ -35,3 +35,31 @@ impl ItemManager {
         &self.items
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ItemManager;
+    use crate::core::config::Config;
+
+    #[test]
+    fn load_empty_list() {
+        let cfg = Config {
+            items: vec![],
+            refresh_secs: 1,
+        };
+        let manager = ItemManager::load(&cfg);
+        assert!(manager.items().is_empty());
+    }
+
+    #[test]
+    fn preserves_order() {
+        let cfg = Config {
+            items: vec!["clock".into(), "unknown".into(), "clock".into()],
+            refresh_secs: 5,
+        };
+        let manager = ItemManager::load(&cfg);
+        assert_eq!(manager.items().len(), 2);
+        assert_eq!(manager.items()[0].name(), "clock");
+        assert_eq!(manager.items()[1].name(), "clock");
+    }
+}

--- a/src/core/item_manager.rs
+++ b/src/core/item_manager.rs
@@ -1,0 +1,37 @@
+// src/core/item_manager.rs
+
+use super::config::Config;
+use super::item::Item;
+use super::items::clock::ClockItem;
+use tracing::warn;
+
+// Manages the set of items for the status bar
+pub struct ItemManager {
+    items: Vec<Box<dyn Item>>,
+}
+
+impl ItemManager {
+    // Loads all enabled items in the order specified by the config.
+    pub fn load(config: &Config) -> Self {
+        let mut items: Vec<Box<dyn Item>> = Vec::new();
+
+        for name in &config.items {
+            match name.as_str() {
+                "clock" => {
+                    // Create a ClockItem with the configured refresh rate
+                    let clock = ClockItem::new(config.refresh_secs as u32);
+                    items.push(Box::new(clock));
+                }
+                other => {
+                    warn!(item = %other, "Unknown item in config, skipping");
+                }
+            }
+        }
+
+        ItemManager { items }
+    }
+
+    pub fn items(&self) -> &[Box<dyn Item>] {
+        &self.items
+    }
+}

--- a/src/core/items/clock.rs
+++ b/src/core/items/clock.rs
@@ -60,7 +60,7 @@ impl Item for ClockItem {
     }
 
     fn start(&self) -> Result<()> {
-        let interval = self.refresh_secs as u32;
+        let interval = self.refresh_secs;
 
         // Grab the initialized Label - panic if widget() wasn't called
         let label = self

--- a/src/core/items/clock.rs
+++ b/src/core/items/clock.rs
@@ -48,6 +48,7 @@ impl Item for ClockItem {
             }
             slot.as_ref().unwrap().clone() // GtkLabel: Clone is a ref-count bump
         };
+        label.style_context().add_class("clock-label");
 
         // Set initial text
         let now = Local::now().format("%H:%M:%S").to_string();

--- a/src/core/items/clock.rs
+++ b/src/core/items/clock.rs
@@ -1,0 +1,64 @@
+// src/core/items/clock.rs
+//
+// A status-bar item displaying the current local time,
+// updating every `refresh_secs` seconds.
+
+use super::super::item::Item;
+use anyhow::Result;
+use chrono::Local;
+use glib::ControlFlow;
+use glib::source::timeout_add_seconds_local;
+use gtk4::prelude::*;
+use gtk4::{Box as GtkBox, Label, Orientation, Widget};
+
+// ClockItem show `HH:MM:SS` and refreshes periodically
+pub struct ClockItem {
+    // How often (in seconds) to update the displayed time
+    refresh_secs: u32,
+    // The GTK Label widget we'll update on each tick.
+    label: Label,
+}
+
+impl ClockItem {
+    // Create a new ClockItem with the given refresh interval.
+    pub fn new(refresh_secs: u32) -> Self {
+        // Initialise the Label now, text will be set in widget()/start()
+        let label = Label::new(None);
+        Self {
+            refresh_secs,
+            label,
+        }
+    }
+}
+
+impl Item for ClockItem {
+    fn name(&self) -> &str {
+        "clock"
+    }
+
+    fn widget(&self) -> Widget {
+        // Build a container forthe clock (in case we add icons or padding)
+        let container = GtkBox::new(Orientation::Horizontal, 4);
+        // Set initial text
+        let now = Local::now().format("%H:%M:%S").to_string();
+        self.label.set_text(&now);
+        // Pack the label into the box
+        container.append(&self.label);
+        // Return as a generic Widget
+        container.upcast::<Widget>()
+    }
+
+    fn start(&self) -> Result<()> {
+        let interval = self.refresh_secs as u32;
+        let label = self.label.clone();
+        // Schedule a repeating timeout on the main context
+        timeout_add_seconds_local(interval, move || {
+            // Update the label text on each tick
+            let now_str = Local::now().format("%H:%M:%S").to_string();
+            // SAFETY: we're in the GTK main thread
+            label.set_text(&now_str);
+            ControlFlow::Continue
+        });
+        Ok(())
+    }
+}

--- a/src/core/items/mod.rs
+++ b/src/core/items/mod.rs
@@ -1,0 +1,4 @@
+// src/core/items/mod.rs
+//! A collection of status-bar item implementations.
+
+pub mod clock;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,3 +3,4 @@
 pub mod config;
 pub mod config_loader;
 pub mod window;
+pub mod item;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,5 +2,6 @@
 
 pub mod config;
 pub mod config_loader;
-pub mod window;
 pub mod item;
+pub mod items;
+pub mod window;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,5 +3,6 @@
 pub mod config;
 pub mod config_loader;
 pub mod item;
+pub mod item_manager;
 pub mod items;
 pub mod window;

--- a/src/core/window.rs
+++ b/src/core/window.rs
@@ -1,12 +1,13 @@
 // src/core/window.rs
 use anyhow::{Context, Result};
 use gtk4::prelude::*;
-use gtk4::{Application, ApplicationWindow};
+use gtk4::{Application, ApplicationWindow, Box, Orientation};
 use gtk4_layer_shell::{Edge, Layer, LayerShell};
 
 use tracing::{error, info};
 
 use super::config::Config;
+use super::item_manager::ItemManager;
 
 // Manages the panel window lifecycle
 pub struct WindowManager {
@@ -32,30 +33,49 @@ impl WindowManager {
         info!("Starting GTK event loop");
         gtk4::init()?;
 
+        // Clone config so we can move it into the ItemManager
+        let config = self._config.clone();
+        // Build the ItemManager from the config
+        let manager = ItemManager::load(&config);
+
         // 1. Create a GTK4 Application with a reverse-domain ID
         let app = Application::new(Some("com.nadirfasola.panel"), Default::default());
 
         // 2. When the app activates, build our panel window
         app.connect_activate(move |app| {
-            let build_ui = || {
-                // 2.a. Create a window tied to the application
-                let window = ApplicationWindow::new(app);
-                window.set_default_size(400, 30); // 400 x 30 px window
-                window.set_decorated(false); // remove titlebar
+            // Create a window tied to the application
+            let window = ApplicationWindow::new(app);
+            window.set_default_size(400, 30); // 400 x 30 px window
+            window.set_decorated(false); // remove titlebar
 
-                // 2.b. Dock it with layer-shell at the bottom
-                window.init_layer_shell();
-                window.set_layer(Layer::Top);
-                window.set_anchor(Edge::Bottom, true);
-                window.set_exclusive_zone(30);
+            // Dock it with layer-shell at the bottom
+            window.init_layer_shell();
+            window.set_layer(Layer::Top);
+            window.set_anchor(Edge::Bottom, true);
+            window.set_exclusive_zone(30);
 
-                // 2.c. Show the window (and all its children)
-                window.show();
-            };
+            // Create the bar's main container
+            let container = Box::new(Orientation::Horizontal, 0);
 
-            if let Err(panic_err) = std::panic::catch_unwind(build_ui) {
-                error!("Panig in GTK callback: {panic_err:?}");
-                std::process::exit(1);
+            // For each item, build its widget and add it
+            for item in manager.items() {
+                let widget = item.widget();
+                container.append(&widget);
+            }
+
+            // Set the container as the window's sole child
+            window.set_child(Some(&container));
+
+            // Show the window (and all its children)
+            window.show();
+
+            // After showing, start each item's background logic
+            for item in manager.items() {
+                if let Err(e) = item.start() {
+                    // Log but don't panic
+                    // One item failing shouldn't kill the bar
+                    error!(item = item.name(), error = %e, "Failed to start item");
+                }
             }
         });
 

--- a/src/core/window.rs
+++ b/src/core/window.rs
@@ -1,8 +1,11 @@
 // src/core/window.rs
 use anyhow::{Context, Result};
-use gtk4::prelude::*;
-use gtk4::{Application, ApplicationWindow, Box, Orientation, CssProvider, style_context_add_provider_for_display, STYLE_PROVIDER_PRIORITY_APPLICATION};
 use gtk4::gdk::Display;
+use gtk4::prelude::*;
+use gtk4::{
+    Application, ApplicationWindow, Box, CssProvider, Orientation,
+    STYLE_PROVIDER_PRIORITY_APPLICATION, style_context_add_provider_for_display,
+};
 use gtk4_layer_shell::{Edge, Layer, LayerShell};
 
 use tracing::{error, info};
@@ -27,8 +30,7 @@ impl WindowManager {
         provider.load_from_path(css_path);
 
         // 3. Grab the default GDK Display
-        let display = Display::default()
-            .expect("Could not get default GDK Display");
+        let display = Display::default().expect("Could not get default GDK Display");
 
         // 4. Add the provider for *all* contexts on this display
         //    This is the correct replacement for gtk_style_context_add_provider_for_display
@@ -40,8 +42,7 @@ impl WindowManager {
     }
 }
 
-impl WindowManager { 
-
+impl WindowManager {
     // Initialises GTK and configuration
     pub fn new() -> Result<Self> {
         info!("Initialising WindowManager");
@@ -65,14 +66,16 @@ impl WindowManager {
         let config = self._config.clone();
         // Build the ItemManager from the config
         let manager = ItemManager::load(&config);
-        info!(num_items = manager.items().len(), "Loaded items from config");
+        info!(
+            num_items = manager.items().len(),
+            "Loaded items from config"
+        );
 
         // 1. Create a GTK4 Application with a reverse-domain ID
         let app = Application::new(Some("com.nadirfasola.panel"), Default::default());
 
         // 2. When the app activates, build our panel window
         app.connect_activate(move |app| {
-
             // Create a window tied to the application
             let window = ApplicationWindow::new(app);
             window.set_default_size(400, 30); // 400 x 30 px window

--- a/tests/item_manager.rs
+++ b/tests/item_manager.rs
@@ -1,0 +1,27 @@
+// tests/item_manager.rs
+
+use panel_rs::core::config::Config;
+use panel_rs::core::item_manager::ItemManager;
+
+#[test]
+fn load_clock_item() {
+    let cfg = Config {
+        items: vec!["bar".into(), "clock".into()],
+        refresh_secs: 1,
+    };
+    let manager = ItemManager::load(&cfg);
+    assert_eq!(manager.items().len(), 1);
+    assert_eq!(manager.items()[0].name(), "clock");
+}
+
+#[test]
+fn skip_unknown_items() {
+    let cfg = Config {
+        items: vec!["foo".into(), "clock".into()],
+        refresh_secs: 1,
+    };
+    let manager = ItemManager::load(&cfg);
+    // "foo" is unknown an should be skipped
+    assert_eq!(manager.items().len(), 1);
+    assert_eq!(manager.items()[0].name(), "clock");
+}


### PR DESCRIPTION
# Description

##Overview

- Introduced a pluggable Item trait for status‑bar widgets. #6 
- Implemented ClockItem with lazy GTK initialization and periodic updates. #5 
- Added ItemManager to load configured item names into boxed trait objects. #6 
- Refactored WindowManager::run() to instantiate, render, and start all items. #7 
- Extended unit tests for ItemManager & simplified Item trait tests (GTK‑free). #8 
- Updated README with a Plugin Architecture section. #9 

## Changes by module

- src/core/item.rs: defined Item trait, added dummy‑item tests.
- src/core/items/clock.rs: refactored ClockItem to delay Label creation, added timer start logic.
- src/core/item_manager.rs: loads items from Config, logs unknown entries.
- src/core/window.rs: loads CSS, builds ItemManager, appends each widget, starts items.
- tests/ & inline module tests updated to cover loading logic without GTK requirements.
- README.md: documented plugin system and “how to add new items.”

## Testing

- cargo fmt, cargo clippy, and cargo test all pass (including headless unit tests).
- Manual cargo run shows the clock centered in the bar via the plugin system.